### PR TITLE
fix: /usr/bin/sed: bad interpreter: No such file or directory

### DIFF
--- a/mario.sed
+++ b/mario.sed
@@ -1,4 +1,4 @@
-#!/usr/bin/sed -Enf
+#!/usr/bin/env -S sed -Enf
 # Sed Mario Bros
 # 10th of December, 2015
 # (C) Ivan Chebykin <ivan4b69@gmail.com>


### PR DESCRIPTION
Using env to find where is located sed.
In my case (debian) it was `/bin/sed`, hence the error